### PR TITLE
added path to OtherFrameworks so that waxsim finds DevToolsFoundation

### DIFF
--- a/WaxSim.xcodeproj/project.pbxproj
+++ b/WaxSim.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WaxSim_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;
-				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\"";
+				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\" \"$(DEVELOPER_DIR)/../OtherFrameworks\"";
 				PRODUCT_NAME = waxsim;
 			};
 			name = Debug;
@@ -187,7 +187,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WaxSim_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;
-				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\"";
+				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\" \"$(DEVELOPER_DIR)/../OtherFrameworks\"";
 				PRODUCT_NAME = waxsim;
 			};
 			name = Release;


### PR DESCRIPTION
The error message was: 

dyld: Library not loaded: @rpath/DevToolsFoundation.framework/Versions/A/DevToolsFoundation
  Referenced from: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/iPhoneSimulatorRemoteClient.framework/Versions/A/iPhoneSimulatorRemoteClient
  Reason: image not found
